### PR TITLE
print all error messages when failed to get chain provider

### DIFF
--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -176,6 +176,19 @@ impl CredentialsError {
             message: message.to_string(),
         }
     }
+
+    /// Merge a string (context) with the current error.
+    pub fn merge_with_str(&mut self, other: &str) {
+        if !self.message.is_empty() {
+            self.message.push(';');
+        }
+        self.message.push_str(other);
+    }
+
+    /// Merge another error with the current error.
+    pub fn merge_with(&mut self, other: &Self) {
+        self.merge_with_str(&other.message)
+    }
 }
 
 impl fmt::Display for CredentialsError {
@@ -383,23 +396,31 @@ impl ChainProvider {
 async fn chain_provider_credentials(
     provider: ChainProvider,
 ) -> Result<AwsCredentials, CredentialsError> {
-    if let Ok(creds) = provider.environment_provider.credentials().await {
-        return Ok(creds);
+    let mut err = CredentialsError {
+        message: "".to_owned(),
+    };
+    match provider.environment_provider.credentials().await {
+        Ok(creds) => return Ok(creds),
+        Err(e) => err.merge_with(&e),
     }
     if let Some(ref profile_provider) = provider.profile_provider {
-        if let Ok(creds) = profile_provider.credentials().await {
-            return Ok(creds);
+        match profile_provider.credentials().await {
+            Ok(creds) => return Ok(creds),
+            Err(e) => err.merge_with(&e),
         }
     }
-    if let Ok(creds) = provider.container_provider.credentials().await {
-        return Ok(creds);
+    match provider.container_provider.credentials().await {
+        Ok(creds) => return Ok(creds),
+        Err(e) => err.merge_with(&e),
     }
-    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
-        return Ok(creds);
+    match provider.instance_metadata_provider.credentials().await {
+        Ok(creds) => return Ok(creds),
+        Err(e) => err.merge_with(&e),
     }
-    Err(CredentialsError::new(
+    err.merge_with_str(
         "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
-    ))
+    );
+    Err(err)
 }
 
 #[async_trait]
@@ -542,6 +563,22 @@ mod tests {
             credentials.expires_at().expect(""),
             DateTime::parse_from_rfc3339("2016-11-18T01:50:39Z").expect("")
         );
+    }
+
+    #[tokio::test]
+    async fn test_chain_error_handling() {
+        let chain = ChainProvider::new();
+
+        match chain.credentials().await {
+            Err(e) => {
+                let cnt = e.message.chars().filter(|x| *x == ';').count();
+                assert!(cnt >= 3, "message: {}", e.message);
+            }
+            Ok(_) => {
+                println!(concat!("the test `test_chain_error_handling` cannot be run: we got the key in the env.",
+                " (which is unexpected, please unset envvars providing cred like `AWS_ACCESS_KEY_ID` or ignore this test.)"))
+            }
+        }
     }
 
     #[cfg(test)]

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -178,7 +178,7 @@ impl CredentialsError {
     }
 
     /// Merge a string (context) with the current error.
-    pub fn merge_with_str(&mut self, other: &str) {
+    fn merge_with_str(&mut self, other: &str) {
         if !self.message.is_empty() {
             self.message.push(';');
         }
@@ -186,7 +186,7 @@ impl CredentialsError {
     }
 
     /// Merge another error with the current error.
-    pub fn merge_with(&mut self, other: &Self) {
+    fn merge_with(&mut self, other: &Self) {
         self.merge_with_str(&other.message)
     }
 }
@@ -397,7 +397,8 @@ async fn chain_provider_credentials(
     provider: ChainProvider,
 ) -> Result<AwsCredentials, CredentialsError> {
     let mut err = CredentialsError {
-        message: "".to_owned(),
+        message: "Couldn't find AWS credentials in environment, credentials file, or IAM role"
+            .to_owned(),
     };
     match provider.environment_provider.credentials().await {
         Ok(creds) => return Ok(creds),
@@ -417,9 +418,6 @@ async fn chain_provider_credentials(
         Ok(creds) => return Ok(creds),
         Err(e) => err.merge_with(&e),
     }
-    err.merge_with_str(
-        "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
-    );
     Err(err)
 }
 
@@ -575,8 +573,10 @@ mod tests {
                 assert!(cnt >= 3, "message: {}", e.message);
             }
             Ok(_) => {
-                println!(concat!("the test `test_chain_error_handling` cannot be run: we got the key in the env.",
-                " (which is unexpected, please unset envvars providing cred like `AWS_ACCESS_KEY_ID` or ignore this test.)"))
+                println!("\
+                the test `test_chain_error_handling` cannot be run: we got the key in the env.\
+                (which is unexpected, please unset envvars providing cred like `AWS_ACCESS_KEY_ID` or ignore this test.)\
+                ")
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
When cannot get any key from the key chain, return all errors we meet.