### PR TITLE
Include ap-southeast-3 in AWS Regions

### DIFF
--- a/rusoto/signature/src/region.rs
+++ b/rusoto/signature/src/region.rs
@@ -58,6 +58,9 @@ pub enum Region {
 
     /// Region that covers the South-Eastern part of Asia Pacific
     ApSoutheast2,
+    
+    /// Region that covers the South-Eastern part of Asia Pacific
+    ApSoutheast3,
 
     /// Region that covers Canada
     CaCentral1,
@@ -144,6 +147,7 @@ impl Region {
             Region::ApSouth1 => "ap-south-1",
             Region::ApSoutheast1 => "ap-southeast-1",
             Region::ApSoutheast2 => "ap-southeast-2",
+            Region::ApSoutheast3 => "ap-southeast-3",
             Region::CaCentral1 => "ca-central-1",
             Region::EuCentral1 => "eu-central-1",
             Region::EuWest1 => "eu-west-1",
@@ -244,6 +248,7 @@ impl FromStr for Region {
             "ap-south-1" | "apsouth1" => Ok(Region::ApSouth1),
             "ap-southeast-1" | "apsoutheast1" => Ok(Region::ApSoutheast1),
             "ap-southeast-2" | "apsoutheast2" => Ok(Region::ApSoutheast2),
+            "ap-southeast-3" | "apsoutheast3" => Ok(Region::ApSoutheast3),
             "ca-central-1" | "cacentral1" => Ok(Region::CaCentral1),
             "eu-central-1" | "eucentral1" => Ok(Region::EuCentral1),
             "eu-west-1" | "euwest1" => Ok(Region::EuWest1),
@@ -319,6 +324,7 @@ mod tests {
         assert_eq!("ap-south-1".parse(), Ok(Region::ApSouth1));
         assert_eq!("ap-southeast-1".parse(), Ok(Region::ApSoutheast1));
         assert_eq!("ap-southeast-2".parse(), Ok(Region::ApSoutheast2));
+        assert_eq!("ap-southeast-3".parse(), Ok(Region::ApSoutheast3));
         assert_eq!("ca-central-1".parse(), Ok(Region::CaCentral1));
         assert_eq!("eu-central-1".parse(), Ok(Region::EuCentral1));
         assert_eq!("eu-west-1".parse(), Ok(Region::EuWest1));
@@ -348,6 +354,7 @@ mod tests {
         assert_tokens(&Region::ApSouth1, &tokens_for_region("ap-south-1"));
         assert_tokens(&Region::ApSoutheast1, &tokens_for_region("ap-southeast-1"));
         assert_tokens(&Region::ApSoutheast2, &tokens_for_region("ap-southeast-2"));
+        assert_tokens(&Region::ApSoutheast3, &tokens_for_region("ap-southeast-3"));
         assert_tokens(&Region::CaCentral1, &tokens_for_region("ca-central-1"));
         assert_tokens(&Region::EuCentral1, &tokens_for_region("eu-central-1"));
         assert_tokens(&Region::EuWest1, &tokens_for_region("eu-west-1"));


### PR DESCRIPTION
Add support for ap-southeast-3 which is now an official AWS region. See https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Added the `ap-southeast-3` region, cherry-picked ae7f34e9c59a8116423e9777bc8429dd8e5f36b5.
