### PR TITLE
support fips

### DIFF
--- a/integration_tests/tests/core.rs
+++ b/integration_tests/tests/core.rs
@@ -18,7 +18,7 @@ async fn get_caller_identity_presigned() {
     request.set_params(params);
     request.add_header("x-test-header", "foobar");
     let url =
-        request.generate_presigned_url(&credentials, &std::time::Duration::from_secs(60), true);
+        request.generate_presigned_url(&credentials, &std::time::Duration::from_secs(60), true).unwrap();
 
     let client = reqwest::Client::new();
     let response = client

--- a/rusoto/core/src/client.rs
+++ b/rusoto/core/src/client.rs
@@ -166,7 +166,8 @@ where
         if credentials.is_anonymous() {
             request.complement();
         } else {
-            request.sign(&credentials);
+            request.sign(&credentials)
+                .map_err(|e| SignAndDispatchError::Credentials(CredentialsError::from(e)))?;
         }
     } else {
         request.complement();

--- a/rusoto/core/src/error.rs
+++ b/rusoto/core/src/error.rs
@@ -126,3 +126,9 @@ impl fmt::Display for InvalidDnsNameError {
         write!(f, "{}", self.message)
     }
 }
+
+impl From<io::Error> for InvalidDnsNameError {
+    fn from(err: io::Error) -> InvalidDnsNameError {
+        InvalidDnsNameError::new(err.to_string())
+    }
+}

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -125,7 +125,7 @@ impl PreSignedRequest for GetObjectRequest {
 
         request.set_params(params);
         request.set_hostname(Some(hostname));
-        Ok(request.generate_presigned_url(credentials, &option.expires_in, false))
+        Ok(request.generate_presigned_url(credentials, &option.expires_in, false)?)
     }
 }
 
@@ -179,7 +179,7 @@ impl PreSignedRequest for PutObjectRequest {
         }
 
         request.set_hostname(Some(hostname));
-        Ok(request.generate_presigned_url(credentials, &option.expires_in, false))
+        Ok(request.generate_presigned_url(credentials, &option.expires_in, false)?)
     }
 }
 
@@ -208,7 +208,7 @@ impl PreSignedRequest for DeleteObjectRequest {
 
         request.set_params(params);
         request.set_hostname(Some(hostname));
-        Ok(request.generate_presigned_url(credentials, &option.expires_in, false))
+        Ok(request.generate_presigned_url(credentials, &option.expires_in, false)?)
     }
 }
 
@@ -239,7 +239,7 @@ impl PreSignedRequest for UploadPartRequest {
 
         request.set_hostname(Some(hostname));
 
-        Ok(request.generate_presigned_url(credentials, &option.expires_in, false))
+        Ok(request.generate_presigned_url(credentials, &option.expires_in, false)?)
     }
 }
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -20280,7 +20280,7 @@ impl S3 for S3Client {
         let mut writer = EventWriter::new(Vec::new());
         DeleteSerializer::serialize(&mut writer, "Delete", &input.delete);
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22403,7 +22403,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22486,7 +22486,7 @@ impl S3 for S3Client {
             &input.cors_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22528,7 +22528,7 @@ impl S3 for S3Client {
             &input.server_side_encryption_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22655,7 +22655,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22700,7 +22700,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22742,7 +22742,7 @@ impl S3 for S3Client {
             &input.bucket_logging_status,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22825,7 +22825,7 @@ impl S3 for S3Client {
             &input.notification_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22910,7 +22910,7 @@ impl S3 for S3Client {
             &input.ownership_controls,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22950,7 +22950,7 @@ impl S3 for S3Client {
         params.put_key("policy");
         request.set_params(params);
         request.set_payload(Some(input.policy.into_bytes()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -22993,7 +22993,7 @@ impl S3 for S3Client {
             &input.replication_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23035,7 +23035,7 @@ impl S3 for S3Client {
             &input.request_payment_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23073,7 +23073,7 @@ impl S3 for S3Client {
         let mut writer = EventWriter::new(Vec::new());
         TaggingSerializer::serialize(&mut writer, "Tagging", &input.tagging);
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23116,7 +23116,7 @@ impl S3 for S3Client {
             &input.versioning_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23158,7 +23158,7 @@ impl S3 for S3Client {
             &input.website_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23340,7 +23340,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23392,7 +23392,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23443,7 +23443,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23499,7 +23499,7 @@ impl S3 for S3Client {
         } else {
             request.set_payload(Some(Vec::new()));
         }
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23542,7 +23542,7 @@ impl S3 for S3Client {
         let mut writer = EventWriter::new(Vec::new());
         TaggingSerializer::serialize(&mut writer, "Tagging", &input.tagging);
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self
@@ -23586,7 +23586,7 @@ impl S3 for S3Client {
             &input.public_access_block_configuration,
         );
         request.set_payload(Some(writer.into_inner()));
-        request.maybe_set_content_md5_header();
+        request.maybe_set_content_md5_header()?;
         request.set_hostname(Some(hostname));
 
         let mut response = self

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -22,17 +22,14 @@ rustc_version = "0.3"
 [dependencies]
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-digest = "0.9.0"
 futures = "0.3"
-hmac = "0.10"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream"] }
 log = "0.4.1"
-md-5 = "0.9"
 base64 = "0.13"
 hex = "0.4"
+openssl = "0.10"
 serde = "1"
-sha2 = "0.9"
 percent-encoding = "2"
 pin-project-lite = "0.2"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -14,6 +14,7 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt;
+use std::io::Error;
 use std::str;
 use std::time::Duration;
 
@@ -154,14 +155,15 @@ impl SignedRequest {
     ///
     /// Has no effect if the payload is not set, or is not a buffer. Will not
     /// override an existing value for the `Content-MD5` header.
-    pub fn maybe_set_content_md5_header(&mut self) {
+    pub fn maybe_set_content_md5_header(&mut self) -> Result<(), Error> {
         if self.headers.contains_key("Content-MD5") {
-            return;
+            return Ok(());
         }
         if let Some(SignedRequestPayload::Buffer(ref payload)) = self.payload {
-            let digest = hash(MessageDigest::md5(), payload).expect("failed to hash with md5");
+            let digest = hash(MessageDigest::md5(), payload)?;
             self.add_header("Content-MD5", &base64::encode(&*digest));
         }
+        Ok(())
     }
 
     /// Returns the current HTTP method
@@ -282,10 +284,10 @@ impl SignedRequest {
         creds: &AwsCredentials,
         expires_in: &Duration,
         should_sha256_sign_payload: bool,
-    ) -> String {
+    ) -> Result<String, Error> {
         debug!("Presigning request URL");
 
-        self.sign(creds);
+        self.sign(creds)?;
         let hostname = self.hostname();
 
         let current_time = Utc::now();
@@ -347,7 +349,7 @@ impl SignedRequest {
             match self.payload {
                 None => Cow::Borrowed(EMPTY_SHA256_HASH),
                 Some(SignedRequestPayload::Buffer(ref payload)) => {
-                    let (digest, _len) = digest_payload(&payload);
+                    let (digest, _len) = digest_payload(&payload)?;
                     Cow::Owned(digest)
                 }
                 Some(SignedRequestPayload::Stream(ref _stream)) => Cow::Borrowed(UNSIGNED_PAYLOAD),
@@ -369,7 +371,7 @@ impl SignedRequest {
         debug!("canonical_request: {:?}", canonical_request);
 
         // use the hashed canonical request to build the string to sign
-        let hashed_canonical_request = to_hexdigest(&canonical_request);
+        let hashed_canonical_request = to_hexdigest(&canonical_request)?;
 
         debug!("hashed_canonical_request: {:?}", hashed_canonical_request);
 
@@ -392,17 +394,17 @@ impl SignedRequest {
             current_time.date().naive_utc(),
             &self.region.name(),
             &self.service,
-        );
+        )?;
         self.params
             .insert("X-Amz-Signature".into(), signature.into());
 
-        format!(
+        Ok(format!(
             "{}://{}{}?{}",
             self.scheme(),
             hostname,
             self.canonical_uri,
             build_canonical_query_string(&self.params)
-        )
+        ))
     }
 
     /// Complement SignedRequest by ensuring the following HTTP headers are set accordingly:
@@ -436,7 +438,7 @@ impl SignedRequest {
 
     /// Signs the request using Amazon Signature version 4 to verify identity.
     /// Authorization header uses AWS4-HMAC-SHA256 for signing.
-    pub fn sign(&mut self, creds: &AwsCredentials) {
+    pub fn sign(&mut self, creds: &AwsCredentials) -> Result<(), Error> {
         self.complement();
         let date = Utc::now();
         self.remove_header("x-amz-date");
@@ -450,7 +452,7 @@ impl SignedRequest {
         let digest = match self.payload {
             None => Cow::Borrowed(EMPTY_SHA256_HASH),
             Some(SignedRequestPayload::Buffer(ref payload)) => {
-                let (digest, _) = digest_payload(&payload);
+                let (digest, _) = digest_payload(&payload)?;
                 Cow::Owned(digest)
             }
             Some(SignedRequestPayload::Stream(_)) => Cow::Borrowed(UNSIGNED_PAYLOAD),
@@ -481,7 +483,7 @@ impl SignedRequest {
         );
 
         // use the hashed canonical request to build the string to sign
-        let hashed_canonical_request = to_hexdigest(&canonical_request);
+        let hashed_canonical_request = to_hexdigest(&canonical_request)?;
         let scope = format!(
             "{}/{}/{}/aws4_request",
             date.format("%Y%m%d"),
@@ -497,7 +499,7 @@ impl SignedRequest {
             date.date().naive_utc(),
             &self.region_for_service(),
             &self.service,
-        );
+        )?;
 
         // build the actual auth header
         let auth_header = format!(
@@ -509,6 +511,7 @@ impl SignedRequest {
         );
         self.remove_header("authorization");
         self.add_header("authorization", &auth_header);
+        Ok(())
     }
 }
 
@@ -579,21 +582,20 @@ impl TryInto<Request<Body>> for SignedRequest {
 }
 
 /// Convert payload from Char array to useable <payload, len> format.
-fn digest_payload(payload: &[u8]) -> (String, usize) {
-    let digest = to_hexdigest(payload);
+fn digest_payload(payload: &[u8]) -> Result<(String, usize), Error> {
+    let digest = to_hexdigest(payload)?;
     let len = payload.len();
-    (digest, len)
+    Ok((digest, len))
 }
 
 #[inline]
-fn hmac(secret: &[u8], message: &[u8]) -> Vec<u8> {
-    let key = PKey::hmac(secret).expect("failed to create hmac");
+fn hmac(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, Error> {
+    let key = PKey::hmac(secret)?;
     let mut signer =
-        Signer::new(MessageDigest::sha256(), &key).expect("failed to create sha256 signer");
+        Signer::new(MessageDigest::sha256(), &key)?;
     signer
-        .update(message)
-        .expect("failed to update the message");
-    signer.sign_to_vec().expect("failed to sign the message")
+        .update(message)?;
+    Ok(signer.sign_to_vec()?)
 }
 
 /// Takes a message and signs it using AWS secret, time, region keys and service keys.
@@ -603,13 +605,13 @@ fn sign_string(
     date: NaiveDate,
     region: &str,
     service: &str,
-) -> String {
+) -> Result<String, Error> {
     let date_str = date.format("%Y%m%d").to_string();
-    let date_hmac = hmac(format!("AWS4{}", secret).as_bytes(), date_str.as_bytes());
-    let region_hmac = hmac(date_hmac.as_ref(), region.as_bytes());
-    let service_hmac = hmac(region_hmac.as_ref(), service.as_bytes());
-    let signing_hmac = hmac(service_hmac.as_ref(), b"aws4_request");
-    hex::encode(hmac(signing_hmac.as_ref(), string_to_sign.as_bytes()).as_slice())
+    let date_hmac = hmac(format!("AWS4{}", secret).as_bytes(), date_str.as_bytes())?;
+    let region_hmac = hmac(date_hmac.as_ref(), region.as_bytes())?;
+    let service_hmac = hmac(region_hmac.as_ref(), service.as_bytes())?;
+    let signing_hmac = hmac(service_hmac.as_ref(), b"aws4_request")?;
+    Ok(hex::encode(hmac(signing_hmac.as_ref(), string_to_sign.as_bytes())?.as_slice()))
 }
 
 /// Mark string as AWS4-HMAC-SHA256 hashed
@@ -753,9 +755,9 @@ pub fn decode_uri(uri: &str) -> String {
     }
 }
 
-fn to_hexdigest<T: AsRef<[u8]>>(t: T) -> String {
-    let digest = hash(MessageDigest::sha256(), t.as_ref()).expect("failed to hash with sha256");
-    hex::encode(digest)
+fn to_hexdigest<T: AsRef<[u8]>>(t: T) -> Result<String, Error> {
+    let digest = hash(MessageDigest::sha256(), t.as_ref())?;
+    Ok(hex::encode(digest))
 }
 
 fn extract_endpoint_path(endpoint: &str) -> Option<&str> {
@@ -855,7 +857,7 @@ mod tests {
             "foo_secret_key",
             None,
             None,
-        ));
+        )).unwrap();
 
         let req: http::Request<Body> = request.try_into().unwrap();
         let expected_uri = Uri::from_static("https://sqs.us-east-1.amazonaws.com");
@@ -877,7 +879,7 @@ mod tests {
             "foo_secret_key",
             None,
             None,
-        ));
+        )).unwrap();
         assert_eq!(
             "/path%20with%20spaces%3A%20the%20sequel",
             request.canonical_uri()
@@ -959,7 +961,7 @@ mod tests {
             date,
             "us-west-1",
             "s3",
-        );
+        ).unwrap();
         assert_eq!(
             signature_foo,
             "74d97a931fb073b276cdb5e5731374b72778cdd29f0764a51dafab99d3e41130".to_string()
@@ -970,7 +972,7 @@ mod tests {
             date,
             "us-west-1",
             "s3",
-        );
+        ).unwrap();
         assert_eq!(
             signature_bar,
             "d767b8a0bc0246f8093953484857d2fd7f43e984377102eede37b0a8dae3d82c".to_string()
@@ -1093,7 +1095,7 @@ mod tests {
             "foo_secret_key",
             None,
             None,
-        ));
+        )).unwrap();
 
         let authorization_headers = request.headers.get("authorization").unwrap();
         let authorization_header = authorization_headers[0].clone();

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -233,7 +233,7 @@ fn generate_payload_serialization(service: &Service<'_>, operation: &Operation) 
     }
 
     if operation.http_checksum_required.unwrap_or(false) {
-        parts.push("request.maybe_set_content_md5_header();".to_owned());
+        parts.push("request.maybe_set_content_md5_header().unwrap();".to_owned());
     }
 
     Some(parts.join("\n"))


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
replace the crypto library, such as hmac, md5 and sha256, by openssl.

The code has passed the test:
```rust
use digest::Digest;
use hmac::{Hmac, Mac, NewMac};
use md5::Md5;
use sha2::Sha256;
use hex;
use openssl::{
    hash::{hash, MessageDigest},
    pkey::PKey,
    sign::Signer,
};

use base64;

fn md5_normal(payload: &[u8]) -> String {
    base64::encode(Md5::digest(payload))
}

fn md5_fips(payload: &[u8]) -> String {
    base64::encode(hash(MessageDigest::md5(), payload).expect("failed to hash with md5"))
}

fn hmac_normal(secret: &[u8], message: &[u8]) -> Hmac<Sha256> {
    let mut hmac = Hmac::<Sha256>::new_varkey(secret).expect("failed to create hmac");
    hmac.update(message);
    hmac
}

fn hmac_fips(secret: &[u8], message: &[u8]) -> Vec<u8> {
    let key = PKey::hmac(secret).expect("failed to create hmac");
    let mut signer = Signer::new(MessageDigest::sha256(), &key).expect("failed to create sha256 signer");
    signer.update(message).expect("failed to update the message");
    signer.sign_to_vec().expect("failed to sign the message")
}

fn sign_string_normal(
    string_to_sign: &str,
    secret: &str,
    date_str: &str,
    region: &str,
    service: &str,
) -> String {
    let date_hmac = hmac_normal(format!("AWS4{}", secret).as_bytes(), date_str.as_bytes())
        .finalize()
        .into_bytes();
    let region_hmac = hmac_normal(date_hmac.as_ref(), region.as_bytes())
        .finalize()
        .into_bytes();
    let service_hmac = hmac_normal(region_hmac.as_ref(), service.as_bytes())
        .finalize()
        .into_bytes();
    let signing_hmac = hmac_normal(service_hmac.as_ref(), b"aws4_request")
        .finalize()
        .into_bytes();
    hex::encode(
        hmac_normal(signing_hmac.as_ref(), string_to_sign.as_bytes())
            .finalize()
            .into_bytes(),
    )
}

fn sign_string_fips(
    string_to_sign: &str,
    secret: &str,
    date_str: &str,
    region: &str,
    service: &str,
) -> String {
    let date_hmac = hmac_fips(format!("AWS4{}", secret).as_bytes(), date_str.as_bytes());
    let region_hmac = hmac_fips(date_hmac.as_ref(), region.as_bytes());
    let service_hmac = hmac_fips(region_hmac.as_ref(), service.as_bytes());
    let signing_hmac = hmac_fips(service_hmac.as_ref(), b"aws4_request");
    hex::encode(
        hmac_fips(signing_hmac.as_ref(), string_to_sign.as_bytes()).as_slice(),
    )
}

fn to_hexdigest_normal<T: AsRef<[u8]>>(t: T) -> String {
    let h = Sha256::digest(t.as_ref());
    hex::encode(h)
}

fn to_hexdigest_fips<T: AsRef<[u8]>>(t: T) -> String {
    let digest = hash(MessageDigest::sha256(), t.as_ref()).expect("failed to hash with sha256");
    hex::encode(digest)
}
use rand::{self, Rng};

fn rand_100_u8() -> Vec<u8> {
    rand::thread_rng()
        .sample_iter(&rand::distributions::Alphanumeric)
        .take(100).collect::<Vec<u8>>()
}

fn rand_100_str() -> String {
    rand::thread_rng()
        .sample_iter(&rand::distributions::Alphanumeric)
        .take(100).map(char::from).collect::<String>()
}

fn main() {
    for _ in 0..1024 {
        let s1 = rand_100_u8();
        // md5
        let md5_1 = md5_normal(&s1);
        let md5_2 = md5_fips(&s1);
        assert!(md5_1 == md5_2);
        println!("{md5_1} : {md5_2}")

        // sha256
        let sha256_1 = to_hexdigest_normal(&s1);
        let sha256_2 = to_hexdigest_fips(&s1);
        assert!(sha256_1 == sha256_2);
        println!("{sha256_1} : {sha256_2}");

        let str1 = rand_100_str();
        let str2 = rand_100_str();
        let str3 = rand_100_str();
        let str4 = rand_100_str();
        let str5 = rand_100_str();
        // hmac
        let hmac_1 = sign_string_normal(&str1, &str2, &str3, &str4, &str5);
        let hmac_2 = sign_string_fips(&str1, &str2, &str3, &str4, &str5);
        assert!(hmac_1 == hmac_2);
        println!("{hmac_1} : {hmac_2}")
    }

}
```