### PR TITLE
Support IMDSv2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - cse
   pull_request:
     branches:
       - master
+      - cse
 
 jobs:
   unit_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Support IMDSv2.
+
 ## [0.46.0] - 2021-01-05
 
 - (Breaking Change) Changed the default S3 addressing style from "path-style" to "virtual-hosted-style"

--- a/rusoto/credential/src/instance_metadata.rs
+++ b/rusoto/credential/src/instance_metadata.rs
@@ -1,7 +1,7 @@
 //! The Credentials Provider for an AWS Resource's IAM Role.
 
 use async_trait::async_trait;
-use hyper::Uri;
+use hyper::{Body, Request, Uri};
 use std::time::Duration;
 
 use crate::request::HttpClient;
@@ -11,6 +11,18 @@ use crate::{
 
 const AWS_CREDENTIALS_PROVIDER_IP: &str = "169.254.169.254";
 const AWS_CREDENTIALS_PROVIDER_PATH: &str = "latest/meta-data/iam/security-credentials";
+const AWS_API_TOKEN_PATH: &str = "latest/api/token";
+const AWS_INSTANCE_METADATA_TOKEN_TTL_SECONDS: &str = "21600"; // 6 hours
+
+/// The version of the Instance Metadata Service (IMDS) to use.
+/// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+#[derive(Clone, Debug)]
+pub enum IMDSVersion {
+    /// Use IMDSv1.
+    V1,
+    /// Use IMDSv2.
+    V2,
+}
 
 /// Provides AWS credentials from a resource's IAM role.
 ///
@@ -45,15 +57,18 @@ pub struct InstanceMetadataProvider {
     client: HttpClient,
     timeout: Duration,
     metadata_ip_addr: String,
+    ver: IMDSVersion,
 }
 
 impl InstanceMetadataProvider {
     /// Create a new provider with the given handle.
+    /// Use IDMSv2 as default, as IDMSv1 may be disabled.
     pub fn new() -> Self {
         InstanceMetadataProvider {
             client: HttpClient::new(),
             timeout: Duration::from_secs(30),
             metadata_ip_addr: AWS_CREDENTIALS_PROVIDER_IP.to_string(),
+            ver: IMDSVersion::V2,
         }
     }
 
@@ -66,6 +81,11 @@ impl InstanceMetadataProvider {
     pub fn set_ip_addr_with_port(&mut self, ip: &str, port: &str) {
         self.metadata_ip_addr = format!("{}:{}", ip, port);
     }
+
+    /// Set the version of the Instance Metadata Service (IMDS) to use.
+    pub fn set_version(&mut self, ver: IMDSVersion) {
+        self.ver = ver;
+    }
 }
 
 impl Default for InstanceMetadataProvider {
@@ -77,17 +97,36 @@ impl Default for InstanceMetadataProvider {
 #[async_trait]
 impl ProvideAwsCredentials for InstanceMetadataProvider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        let role_name = get_role_name(&self.client, self.timeout, &self.metadata_ip_addr)
-            .await
-            .map_err(|err| CredentialsError {
-                message: format!("Could not get credentials from iam: {}", err.to_string()),
-            })?;
+        let token = match self.ver {
+            IMDSVersion::V1 => None,
+            IMDSVersion::V2 => Some(
+                get_token(&self.client, self.timeout, &self.metadata_ip_addr)
+                    .await
+                    .map_err(|err| CredentialsError {
+                        message: format!(
+                            "Could not get token from metadata service: {}",
+                            err.to_string()
+                        ),
+                    })?,
+            ),
+        };
+        let role_name = get_role_name(
+            &self.client,
+            self.timeout,
+            &self.metadata_ip_addr,
+            token.as_deref(),
+        )
+        .await
+        .map_err(|err| CredentialsError {
+            message: format!("Could not get credentials from iam: {}", err.to_string()),
+        })?;
 
         let cred_str = get_credentials_from_role(
             &self.client,
             self.timeout,
             &role_name,
             &self.metadata_ip_addr,
+            token.as_deref(),
         )
         .await
         .map_err(|err| CredentialsError {
@@ -98,11 +137,42 @@ impl ProvideAwsCredentials for InstanceMetadataProvider {
     }
 }
 
+/// Gets a token from the EC2 Instance Metadata Service.
+/// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
+async fn get_token(
+    client: &HttpClient,
+    timeout: Duration,
+    ip_addr: &str,
+) -> Result<String, CredentialsError> {
+    let token_address = format!("http://{}/{}", ip_addr, AWS_API_TOKEN_PATH);
+    let uri = match token_address.parse::<Uri>() {
+        Ok(u) => u,
+        Err(e) => {
+            return Err(CredentialsError {
+                message: format!("Invalid address to get token: {}: {:?}", token_address, e),
+            })
+        }
+    };
+    let req = Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header(
+            "X-aws-ec2-metadata-token-ttl-seconds",
+            AWS_INSTANCE_METADATA_TOKEN_TTL_SECONDS,
+        )
+        .body(Body::empty())
+        .map_err(|e| CredentialsError {
+            message: format!("Could not create request for get token: {:?}", e),
+        })?;
+    Ok(client.request(req, timeout).await?)
+}
+
 /// Gets the role name to get credentials for using the IAM Metadata Service (169.254.169.254).
 async fn get_role_name(
     client: &HttpClient,
     timeout: Duration,
     ip_addr: &str,
+    token: Option<&str>,
 ) -> Result<String, CredentialsError> {
     let role_name_address = format!("http://{}/{}/", ip_addr, AWS_CREDENTIALS_PROVIDER_PATH);
     let uri = match role_name_address.parse::<Uri>() {
@@ -110,7 +180,7 @@ async fn get_role_name(
         Err(e) => return Err(CredentialsError::new(e)),
     };
 
-    Ok(client.get(uri, timeout).await?)
+    Ok(client.get(uri, timeout, token).await?)
 }
 
 /// Gets the credentials for an EC2 Instances IAM Role.
@@ -119,6 +189,7 @@ async fn get_credentials_from_role(
     timeout: Duration,
     role_name: &str,
     ip_addr: &str,
+    token: Option<&str>,
 ) -> Result<String, CredentialsError> {
     let credentials_provider_url = format!(
         "http://{}/{}/{}",
@@ -130,5 +201,5 @@ async fn get_credentials_from_role(
         Err(e) => return Err(CredentialsError::new(e)),
     };
 
-    Ok(client.get(uri, timeout).await?)
+    Ok(client.get(uri, timeout, token).await?)
 }

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -14,6 +14,7 @@ pub use crate::profile::ProfileProvider;
 pub use crate::secrets::Secret;
 pub use crate::static_provider::StaticProvider;
 pub use crate::variable::Variable;
+pub use crate::instance_metadata::IMDSVersion;
 
 pub mod claims;
 mod container;

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -9,12 +9,12 @@
 
 pub use crate::container::ContainerProvider;
 pub use crate::environment::EnvironmentProvider;
+pub use crate::instance_metadata::IMDSVersion;
 pub use crate::instance_metadata::InstanceMetadataProvider;
 pub use crate::profile::ProfileProvider;
 pub use crate::secrets::Secret;
 pub use crate::static_provider::StaticProvider;
 pub use crate::variable::Variable;
-pub use crate::instance_metadata::IMDSVersion;
 
 pub mod claims;
 mod container;

--- a/rusoto/credential/tests/instance-profile-test.rs
+++ b/rusoto/credential/tests/instance-profile-test.rs
@@ -1,4 +1,4 @@
-use rusoto_credential::{InstanceMetadataProvider, ProvideAwsCredentials};
+use rusoto_credential::{InstanceMetadataProvider, ProvideAwsCredentials, IMDSVersion};
 use std::time::Duration;
 
 // This test is marked ignored because it requires special setup.
@@ -6,10 +6,16 @@ use std::time::Duration;
 #[tokio::test]
 #[ignore]
 async fn it_fetches_basic_role() {
+    fetches_basic_role_impl(IMDSVersion::V1).await;
+    fetches_basic_role_impl(IMDSVersion::V2).await;
+}
+
+async fn fetches_basic_role_impl(ver: IMDSVersion) {
     // set env vars to point to local provider
     let mut provider = InstanceMetadataProvider::new();
     provider.set_timeout(Duration::from_secs(5));
     provider.set_ip_addr_with_port("127.0.0.1", "8080");
+    provider.set_version(ver);
 
     let creds = provider.credentials().await.expect("credentials");
 

--- a/rusoto/credential/tests/instance-profile-test.rs
+++ b/rusoto/credential/tests/instance-profile-test.rs
@@ -1,4 +1,4 @@
-use rusoto_credential::{InstanceMetadataProvider, ProvideAwsCredentials, IMDSVersion};
+use rusoto_credential::{IMDSVersion, InstanceMetadataProvider, ProvideAwsCredentials};
 use std::time::Duration;
 
 // This test is marked ignored because it requires special setup.

--- a/rusoto/credential_service_mock/src/main.rs
+++ b/rusoto/credential_service_mock/src/main.rs
@@ -27,13 +27,48 @@ const ROLE_JSON: &str = r#"{
   "Expiration" : "2015-08-04T06:32:37Z"
 }"#;
 
+const TOKEN: &str = "toKEn";
+
+const TOKEN_HEADER: &str = "X-aws-ec2-metadata-token";
+
+fn check_token(req: &Request<Body>) -> bool {
+    if let Some(v) = req.headers().get(TOKEN_HEADER) {
+        return String::from_utf8_lossy(v.as_bytes()).as_ref() == TOKEN;
+    }
+    true
+}
+
 async fn handle(req: Request<Body>) -> Response<Body> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/latest/meta-data/iam/security-credentials/") => {
+            if !check_token(&req) {
+                return Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(Body::from("invalid token"))
+                    .unwrap();
+            }
             Response::new(Body::from("testrole"))
         }
         (&Method::GET, "/latest/meta-data/iam/security-credentials/testrole") => {
+            if !check_token(&req) {
+                return Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(Body::from("invalid token"))
+                    .unwrap();
+            }
             Response::new(Body::from(ROLE_JSON))
+        }
+        (&Method::PUT, "/latest/api/token") => {
+            if !req
+                .headers()
+                .contains_key("X-aws-ec2-metadata-token-ttl-seconds")
+            {
+                return Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("missing header"))
+                    .unwrap();
+            }
+            Response::new(Body::from(TOKEN))
         }
         _ => Response::builder()
             .status(StatusCode::BAD_REQUEST)


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Access to S3 meet the following on an EC2 instance with IAM role having permission of S3 actions:

`[2024/06/05 07:57:52.996 +00:00] [WARN] [util.rs:90] ["aws request meet error."] [uuid=10ed33a3-a245-40d0-b4ff-40bf02b8c7dc] [context=get_cred_on_premise] [retry?=true] [err="Couldn't find AWS credentials in environment, credentials file, or IAM role;No (or empty) AWS_ACCESS_KEY_ID in environment;Couldn't stat credentials file: [ \"/home/ec2-user/.aws/credentials\" ]. Non existant, or no permission.;Could not get request from environment: Neither environment variable 'AWS_CONTAINER_CREDENTIALS_FULL_URI' nor 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' is set;Could not get credentials from iam: invalid uri character"]`

There are 2 issues:

1. The error message of `invalid uri charactor` was misleadering. The `security-credentials` API actually returned the 401 error, but we do not check the status code, and consider error message as role name:

```
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>401 - Unauthorized</title>
 </head>
 <body>
  <h1>401 - Unauthorized</h1>
 </body>
```

2. EC2 instance was configured as "Required" [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html), but we do not support `IMDSv2`.

In this PR:

- Check HTTP status code, and return error if it's not a successful code.
- Support `IMDSv2`.

### Manual Test

- Show S3 file by code of baseline

```
./show --id 450254793210069006
Jun 06 10:33:35.447 WARN aws request meet error., uuid: 0ea65fe7-45da-4963-8b71-d0c3553476cd, context: get_cred_on_premise, retry?: true, err: Couldn't find AWS credentials in environment, credentials file, or IAM role;No (or empty) AWS_ACCESS_KEY_ID in environment;Couldn't stat credentials file: [ "/home/ec2-user/.aws/credentials" ]. Non existant, or no permission.;Could not get request from environment: Neither environment variable 'AWS_CONTAINER_CREDENTIALS_FULL_URI' nor 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' is set;Could not get credentials from iam: invalid uri character
Jun 06 10:33:36.557 WARN aws request meet error., uuid: 0ea65fe7-45da-4963-8b71-d0c3553476cd, context: get_cred_on_premise, retry?: true, err: Couldn't find AWS credentials in environment, credentials file, or IAM role;No (or empty) AWS_ACCESS_KEY_ID in environment;Couldn't stat credentials file: [ "/home/ec2-user/.aws/credentials" ]. Non existant, or no permission.;Could not get request from environment: Neither environment variable 'AWS_CONTAINER_CREDENTIALS_FULL_URI' nor 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' is set;Could not get credentials from iam: invalid uri character
```

- Show S3 file with new codes of this PR

```
./show-new --id 450254793210069006
Jun 06 10:33:41.122 INFO read file 450254793210069006, size 128411, takes 80ms, retry 0
...
...
```
