### PR TITLE
credential: update shlex dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - cse
 
 env:
-  RUST_VERSION: 'nightly-2022-11-15'
+  RUST_VERSION: 'nightly-2026-01-30'
 
 jobs:
   unit_tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -47,13 +47,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -72,13 +72,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -97,13 +97,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up Rust
@@ -131,7 +131,7 @@ jobs:
         rust-version: ${{ env.RUST_VERSION }}
         components: rustfmt
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -146,13 +146,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -167,13 +167,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -188,14 +188,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Rust
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ env.RUST_VERSION }}
         components: rustfmt
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry

--- a/rusoto/core/src/proto/xml/util.rs
+++ b/rusoto/core/src/proto/xml/util.rs
@@ -42,7 +42,7 @@ pub struct XmlResponse<'b> {
 }
 
 impl<'b> XmlResponse<'b> {
-    pub fn new(stack: Peekable<Events<&'b [u8]>>) -> XmlResponse {
+    pub fn new(stack: Peekable<Events<&'b [u8]>>) -> XmlResponse<'b> {
         XmlResponse { xml_stack: stack }
     }
 }

--- a/rusoto/core/src/serialization.rs
+++ b/rusoto/core/src/serialization.rs
@@ -361,7 +361,9 @@ mod tests {
         s: &str,
     ) -> Result<
         B,
-        <&mut serde_json::de::Deserializer<serde_json::de::StrRead> as serde::Deserializer>::Error,
+        <&mut serde_json::de::Deserializer<serde_json::de::StrRead<'_>> as serde::Deserializer<
+            '_,
+        >>::Error,
     > {
         let reader = serde_json::de::StrRead::new(s);
         let mut deserializer = serde_json::de::Deserializer::new(reader);
@@ -381,7 +383,9 @@ mod tests {
         s: &str,
     ) -> Result<
         B,
-        <&mut serde_json::de::Deserializer<serde_json::de::StrRead> as serde::Deserializer>::Error,
+        <&mut serde_json::de::Deserializer<serde_json::de::StrRead<'_>> as serde::Deserializer<
+            '_,
+        >>::Error,
     > {
         let reader = serde_json::de::StrRead::new(s);
         let mut deserializer = serde_json::de::Deserializer::new(reader);

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shlex = "0.1"
+shlex = "1.3"
 tokio = { version = "1.0", features = ["process", "sync", "time"] }
 zeroize = "1"
 

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -46,5 +46,8 @@ serde_json = "1"
 serde_test = "1"
 tokio = { version = "1.0", features = ["io-util"] }
 
+[features]
+unstable = []
+
 [package.metadata.docs.rs]
 targets = []


### PR DESCRIPTION
Update `rusoto_credential` to use `shlex = "1.3"` instead of `shlex = "0.1"` to avoid RUSTSEC-2024-0006 while preserving the existing `cse` branch API surface.

Validation:
- `cargo +nightly-2026-01-30 test -p rusoto_credential`